### PR TITLE
Added .7z support for RetroArch ParaLLel_n64 core

### DIFF
--- a/platforms/Nintendo64.json
+++ b/platforms/Nintendo64.json
@@ -89,8 +89,8 @@
     {
       "name": "RetroArch (64 bits) - parallel_n64",
       "uniqueId": "n64.ra64.parallel_n64",
-      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64.",
-      "acceptedFilenameRegex": "^(.*)\\.(?:bin|n64|ndd|u1|v64|z64)$",
+      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64, 7z.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:bin|n64|ndd|u1|v64|z64|7z)$",
       "amStartArguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch.aarch64/cores/parallel_n64_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch.aarch64/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch.aarch64\n  -e APK /data/app/com.retroarch.aarch64-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch.aarch64/files\n  --activity-clear-task\n  --activity-clear-top",
       "killPackageProcesses": true,
       "killPackageProcessesWarning": true,
@@ -119,8 +119,8 @@
     {
       "name": "RetroArch (32 bits) - parallel_n64",
       "uniqueId": "n64.ra32.parallel_n64",
-      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64.",
-      "acceptedFilenameRegex": "^(.*)\\.(?:bin|n64|ndd|u1|v64|z64)$",
+      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64, 7z.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:bin|n64|ndd|u1|v64|z64|7z)$",
       "amStartArguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch.ra32/cores/parallel_n64_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch.ra32/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch.ra32\n  -e APK /data/app/com.retroarch.ra32-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch.ra32/files\n  --activity-clear-task\n  --activity-clear-top",
       "killPackageProcesses": true,
       "killPackageProcessesWarning": true,
@@ -149,8 +149,8 @@
     {
       "name": "RetroArch - parallel_n64",
       "uniqueId": "n64.ra.parallel_n64",
-      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64.",
-      "acceptedFilenameRegex": "^(.*)\\.(?:bin|n64|ndd|u1|v64|z64)$",
+      "description": "Supported extensions: bin, n64, ndd, u1, v64, z64, 7z.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:bin|n64|ndd|u1|v64|z64|7z)$",
       "amStartArguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch/cores/parallel_n64_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch\n  -e APK /data/app/com.retroarch-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch/files\n  --activity-clear-task\n  --activity-clear-top",
       "killPackageProcesses": true,
       "killPackageProcessesWarning": true,


### PR DESCRIPTION
The ParaLLel core has support for .7z files but the platform files doesn't allow compressed 7zip roms to be used, this just adds the apropiate .7z support