### PR TITLE
Update platforms.json link to platforms/index.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
 ---
 
 
-The complete platform list is available in [platforms.json](platforms.json).
+The complete platform list is available in [index.json](platforms/index.json).
 
 ---
 


### PR DESCRIPTION
Fix broken link to point at `platforms/index.json`.