### PR TITLE
Add AzaharPlus to Nintendo3DS.json

### DIFF
--- a/platforms/Nintendo3DS.json
+++ b/platforms/Nintendo3DS.json
@@ -56,6 +56,16 @@
       "extra": ""
     },
     {
+      "name": "AzaharPlus",
+      "uniqueId": "io.github.azaharplus.android",
+      "description": "Supported extensions: 3ds, app, cci, cxi, zcci, zcxi.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:3ds|app|cci|cxi|zcci|zcxi|cia)$",
+      "amStartArguments": "-n io.github.azaharplus.android/org.citra.citra_emu.activities.EmulationActivity\n  -a android.intent.action.VIEW\n  -d {file.uri}\n  --activity-clear-task\n  --activity-clear-top\n",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
+    {
       "name": "Borked 3DS",
       "uniqueId": "3ds.io.github.borked3ds.android",
       "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf.",


### PR DESCRIPTION
By popular demand, adding the popular fork [AzaharPlus](https://github.com/AzaharPlus/AzaharPlus) (`io.github.azaharplus.android` | "coexist variant" `azaharplus-2125.0-A-android_coexists_with_azahar.apk`)

Launch command tested and confirmed via:
```
adb shell am start \
  -n io.github.azaharplus.android/org.citra.citra_emu.activities.EmulationActivity \
  -a android.intent.action.VIEW \
  -d "file:///storage/emulated/0/Emulation/azahar/sdmc/Nintendo\ 3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000/000d5a00/content/00000000.app" \
  --activity-clear-task \
  --activity-clear-top
```

<img width="836" height="272" alt="Screenshot 2026-04-16 at 14 11 21 PM of Discord (#cocoon-help  Cocoon - Discord)" src="https://github.com/user-attachments/assets/5ea58494-3910-4077-97de-e5888c91bbec" />
<img width="842" height="302" alt="Screenshot 2026-04-16 at 14 11 05 PM of Discord (#cocoon-help  Cocoon - Discord)" src="https://github.com/user-attachments/assets/a17ab881-80ad-41e1-b683-b66df2faf545" />
