### PR TITLE
Expand acceptedFilenameRegex for GameNative to accept .steam files

### DIFF
--- a/platforms/Steam.json
+++ b/platforms/Steam.json
@@ -75,7 +75,7 @@
       "name": "GameNative",
       "uniqueId": "steam.app.gamenative",
       "description": "GameNative",
-      "acceptedFilenameRegex": "^(.*)\\.(?:steamappid)$",
+      "acceptedFilenameRegex": "^(.*)\\.(?:steamappid|steam)$",
       "amStartArguments": "-a app.gamenative.LAUNCH_GAME\n -n app.gamenative/.MainActivity\n --ei app_id {tags.steamappid}\n",
       "killPackageProcesses": false,
       "killPackageProcessesWarning": false,


### PR DESCRIPTION
GameNative's v1.0.0 release includes an automatic frontend sync that creates `.steam` files in a user-set directory, This change enhances Cocoon's game scanning to associate these files with GameNative.