### PR TITLE
Add AzaharPlus emulator entries for Nintendo 3DS

### DIFF
--- a/platforms/Nintendo3DS.json
+++ b/platforms/Nintendo3DS.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 13,
+  "revisionNumber": 14,
   "platform": {
     "name": "Nintendo 3DS",
     "uniqueId": "n3ds",
@@ -25,6 +25,26 @@
     "extra": ""
   },
   "playerList": [
+    {
+      "name": "AzaharPlus",
+      "uniqueId": "3ds.azaharplus",
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf, zcci, zcxi, cia. Fork of Azahar with extra features and broader file compatibility. Coexists with Azahar (New).",
+      "acceptedFilenameRegex": "^(.*)\\.(?:3ds|3dsx|app|axf|cci|cxi|elf|zcci|zcxi|cia)$",
+      "amStartArguments": "-n io.github.azaharplus.android/org.citra.citra_emu.activities.EmulationActivity\n  -a android.intent.action.VIEW\n  -d {file.uri}\n  --activity-clear-task\n  --activity-clear-top\n",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
+    {
+      "name": "AzaharPlus (replaces Azahar)",
+      "uniqueId": "3ds.azaharplus.replaces",
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf, zcci, zcxi, cia. Fork of Azahar with extra features. Replaces Azahar (uses same package ID as legacy Azahar).",
+      "acceptedFilenameRegex": "^(.*)\\.(?:3ds|3dsx|app|axf|cci|cxi|elf|zcci|zcxi|cia)$",
+      "amStartArguments": "-n io.github.lime3ds.android/org.citra.citra_emu.activities.EmulationActivity\n  -a android.intent.action.VIEW\n  -d {file.uri}\n  --activity-clear-task\n  --activity-clear-top\n",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
     {
       "name": "Azahar",
       "uniqueId": "3ds.azahar",


### PR DESCRIPTION
## Summary

Adds two entries for [AzaharPlus](https://github.com/AzaharPlus/AzaharPlus), a fork of Azahar with extra features:

- Broader file compatibility (3ds, 3dsx, app, axf, cci, cxi, elf, zcci, zcxi, cia)
- Ability to download system files from official servers
- ZipPass (StreetPass data via zip files)
- Compatibility with older CPUs (no SSE4.2 required) and Android 9

### Entries added

| Name | Package ID | APK variant |
|------|-----------|-------------|
| AzaharPlus | `io.github.azaharplus.android` | coexists with Azahar |
| AzaharPlus (replaces Azahar) | `io.github.lime3ds.android` | replaces legacy Azahar |

Package IDs were verified directly from the release APK manifests (tag `AZAHAR_PLUS_2125_1_B`).