### PR TITLE
Add ARMSX2 refresh to PS2 platform JSON

### DIFF
--- a/platforms/SonyPlayStation2.json
+++ b/platforms/SonyPlayStation2.json
@@ -75,6 +75,16 @@
       "extra": ""
     },
     {
+      "name": "ARMSX2 (Refresh)",
+      "uniqueId": "ps2.com.armsx2",
+      "description": "Supported extensions: iso, chd, gz.",
+      "acceptedFilenameRegex": "^(.*).(?:iso|chd|gz|mdf|bin|ciso|img)$",
+      "amStartArguments": "-n com.armsx2/com.armsx2.MainActivity\n -a android.intent.action.VIEW\n -d {file.uri}\n --grant-read-uri-permission \n --activity-clear-task \n --activity-clear-top \n ",
+      "killPackageProcesses": true,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
+    {
       "name": "RetroArch (64 bits) - play",
       "uniqueId": "ps2.ra64.play",
       "description": "Supported extensions: bin, cso, elf, iso, isz.",


### PR DESCRIPTION
ARMSX2 is getting a rewrite and has been moving along quite quickly in a short span of time. This has been tested manually using the import platforms feature on Cocoon.

Branch of current ARMSX2 Refresh development: https://github.com/ARMSX2/ARMSX2/tree/refresh-experimental