### PR TITLE
Add Pixl8 support to PICO8 platform configuration

### DIFF
--- a/platforms/PICO8.json
+++ b/platforms/PICO8.json
@@ -41,6 +41,16 @@
       "extra": ""
     },
     {
+      "name": "Pixl8",
+      "uniqueId": "pico8.be.codedreams.pixl8",
+      "description": "Supported extensions: p8, png.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:p8|png)$",
+      "amStartArguments": "-n be.codedreams.pixl8/.MainActivity\n -a android.intent.action.VIEW\n -d {file.uri}",
+      "killPackageProcesses": true,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
+    {
       "name": "Infinity P8 Player",
       "uniqueId": "pico8.me.dt2dev.infinity",
       "description": "Supported extensions: p8, png.",


### PR DESCRIPTION
Adds the Pixl8 emulator to the PICO8 supported emulators list.
Followed this guide:
https://pixl8.dev/launchers.html