### PR TITLE
[codex] Add OpenSw Nintendo Switch player

### DIFF
--- a/platforms/NintendoSwitch.json
+++ b/platforms/NintendoSwitch.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 17,
+  "revisionNumber": 18,
   "platform": {
     "name": "Nintendo Switch",
     "uniqueId": "switch",
@@ -37,6 +37,16 @@
       "description": "Supported extensions: nro, nso, nca, xci, nsp.",
       "acceptedFilenameRegex": "^(.*)\\.(?:nro|nso|nca|xci|nsp)$",
       "amStartArguments": "-n org.stratoemu.strato/org.stratoemu.strato.EmulationActivity\n  -a android.intent.action.VIEW\n  -d {file.uri}",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": false,
+      "extra": ""
+    },
+    {
+      "name": "OpenSw",
+      "uniqueId": "switch.com.remipelloux.opensw",
+      "description": "Supported extensions: nro, nso, nca, xci, nsp.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:nro|nso|nca|xci|nsp)$",
+      "amStartArguments": "-n com.remipelloux.opensw/org.yuzu.yuzu_emu.activities.EmulationActivity\n  -a android.nfc.action.TECH_DISCOVERED\n  -d {file.uri}",
       "killPackageProcesses": false,
       "killPackageProcessesWarning": false,
       "extra": ""


### PR DESCRIPTION
## What changed

- add OpenSw as a Nintendo Switch player
- launch `com.remipelloux.opensw` through its exported emulation activity
- increment the Nintendo Switch configuration revision

## Why

Cocoon currently discovers the installed OpenSw application through Android's game category, but it cannot select it for Nintendo Switch games because the `gamenative` player list does not include its package.

## Validation

- validated `platforms/NintendoSwitch.json` with `jq`
- confirmed the package and exported activity on an AYN Thor running OpenSw
