### PR TITLE
Add DolphinCS player to GameCube and Wii

### DIFF
--- a/platforms/GameCube.json
+++ b/platforms/GameCube.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 12,
+  "revisionNumber": 13,
   "platform": {
     "name": "GameCube",
     "uniqueId": "gc",
@@ -123,6 +123,16 @@
       "acceptedFilenameRegex": "^(.*)\\.(?:ciso|dff|dol|elf|gcm|gcz|iso|m3u|rvz|tgc|wad|wbfs|wia)$",
       "amStartArguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch/cores/dolphin_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch\n  -e APK /data/app/com.retroarch-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch/files\n --activity-new-task\n --activity-clear-top",
       "killPackageProcesses": true,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    }
+    {
+      "name": "DolphinCS",
+      "uniqueId": "gc.com.joeyos.dolphinemu",
+      "description": "Supported extensions: ciso, dff, dol, elf, gcm, gcz, iso, tgc, wad, wbfs, rvz.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:ciso|dff|dol|elf|gcm|gcz|iso|tgc|wad|wbfs|rvz|m3u)$",
+      "amStartArguments": "-n com.joeyos.dolphinemu/org.dolphinemu.dolphinemu.ui.main.MainActivity\n  -a android.intent.action.VIEW\n  -e AutoStartFile {file.uri}",
+      "killPackageProcesses": false,
       "killPackageProcessesWarning": true,
       "extra": ""
     }

--- a/platforms/GameCube.json
+++ b/platforms/GameCube.json
@@ -125,7 +125,7 @@
       "killPackageProcesses": true,
       "killPackageProcessesWarning": true,
       "extra": ""
-    }
+    },
     {
       "name": "DolphinCS",
       "uniqueId": "gc.com.joeyos.dolphinemu",

--- a/platforms/NintendoWii.json
+++ b/platforms/NintendoWii.json
@@ -136,7 +136,7 @@
       "killPackageProcesses": true,
       "killPackageProcessesWarning": true,
       "extra": ""
-    }
+    },
     {
       "name": "DolphinCS",
       "uniqueId": "wii.com.joeyos.dolphinemu",

--- a/platforms/NintendoWii.json
+++ b/platforms/NintendoWii.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 10,
+  "revisionNumber": 11,
   "platform": {
     "name": "Nintendo Wii",
     "uniqueId": "wii",
@@ -134,6 +134,16 @@
       "acceptedFilenameRegex": "^(.*)\\.(?:ciso|dff|dol|elf|gcm|gcz|iso|m3u|rvz|tgc|wad|wbfs|wia)$",
       "amStartArguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch/cores/dolphin_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch\n  -e APK /data/app/com.retroarch-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch/files\n --activity-new-task\n --activity-clear-top",
       "killPackageProcesses": true,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    }
+    {
+      "name": "DolphinCS",
+      "uniqueId": "wii.com.joeyos.dolphinemu",
+      "description": "Supported extensions: ciso, dff, dol, elf, gcm, gcz, iso, tgc, wad, wbfs, rvz.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:ciso|dff|dol|elf|gcm|gcz|iso|tgc|wad|wbfs|rvz|m3u)$",
+      "amStartArguments": "-n com.joeyos.dolphinemu/org.dolphinemu.dolphinemu.ui.main.MainActivity\n  -a android.intent.action.VIEW\n  -e AutoStartFile {file.uri}",
+      "killPackageProcesses": false,
       "killPackageProcessesWarning": true,
       "extra": ""
     }


### PR DESCRIPTION
DolphinCS is a Dolphin fork for Android whose only change is a configurable user data storage location (scoped storage / internal / SD card). Handheld users are picking it up because standalone Dolphin's app-private user directory can't be reached by file managers or sync tools like Syncthing. It uses a distinct `applicationId`, so it installs alongside official Dolphin rather than replacing it, but that also means Cocoon doesn't list it.

The fork changes only `applicationId`; the Java package, activity, intent action and `AutoStartFile` extra are untouched, so the entry follows the existing `org.dolphinemu.handheld` pattern (full activity path rather than the `.ui.main.MainActivity` shorthand).

Verified on an AYN Thor, Android 13, DolphinCS `2606-8`. Launcher activity resolves to `com.joeyos.dolphinemu/org.dolphinemu.dolphinemu.ui.main.MainActivity`.

Repo: https://github.com/JoeysRetroHandhelds/DolphinCS