### PR TITLE
Add RetroArchLnk mGBA player for GBA

### DIFF
--- a/platforms/GameBoyAdvance.json
+++ b/platforms/GameBoyAdvance.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 12,
+  "revisionNumber": 13,
   "platform": {
     "name": "Game Boy Advance",
     "uniqueId": "gba",
@@ -122,6 +122,16 @@
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "acceptedFilenameRegex": "^(.*)\\.(?:gb|gba|gbc|zip|7z)$",
       "amStartArguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch.aarch64/cores/mgba_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch.aarch64/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch.aarch64\n  -e APK /data/app/com.retroarch.aarch64-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch.aarch64/files\n  --activity-clear-task\n  --activity-clear-top",
+      "killPackageProcesses": true,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
+     {
+      "name": "RetroArchLnk (64 bits) - mgba",
+      "uniqueId": "gba.ralnk64.mgba",
+      "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:gb|gba|gbc|zip|7z)$",
+      "amStartArguments": "-n com.retroarch.lnk.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture\n  -e ROM {file.path}\n  -e LIBRETRO /data/data/com.retroarch.lnk.aarch64/cores/mgba_libretro_android.so\n  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch.lnk.aarch64/files/retroarch.cfg\n  -e IME com.android.inputmethod.latin/.LatinIME\n  -e DATADIR /data/data/com.retroarch.lnk.aarch64\n  -e APK /data/app/com.retroarch.lnk.aarch64-1/base.apk\n  -e SDCARD /storage/emulated/0\n  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch.lnk.aarch64/files\n  --activity-clear-task\n  --activity-clear-top",
       "killPackageProcesses": true,
       "killPackageProcessesWarning": true,
       "extra": ""

--- a/platforms/index.json
+++ b/platforms/index.json
@@ -279,7 +279,7 @@
       "platformName": "Game Boy Advance",
       "platformShortname": "gba",
       "platformUniqueId": "gba",
-      "revisionNumber": 12
+      "revisionNumber": 13
     },
     {
       "filename": "GameBoyColor.json",


### PR DESCRIPTION
Adds a new **RetroArchLnk (64 bits) - mGBA** player option for Game Boy Advance.

RetroArchLnk uses the Android package:

`com.retroarch.lnk.aarch64`

This allows Cocoon to launch GBA games through RetroArchLnk instead of the standard RetroArch package, which is useful for compatibility with **EmuLnk** on supported dual-screen Android handhelds such as the AYN Thor.

The new player keeps the existing mGBA launch configuration but updates the package and data paths to point to RetroArchLnk.

Also updates the GBA platform revision from **12 to 13** in both `GameBoyAdvance.json` and `index.json`.
